### PR TITLE
[BUGFIX] f:flashMessages error with renderMode v8

### DIFF
--- a/Resources/Private/Templates/YoutubeData/List.html
+++ b/Resources/Private/Templates/YoutubeData/List.html
@@ -4,7 +4,7 @@
      xmlns:f="http://typo3.org/ns/fluid/ViewHelpers">
 
 <f:section name="Main">
-    <f:flashMessages renderMode="div" />
+    <f:flashMessages />
     <f:if condition="{videos}">
         <f:for each="{videos}" as="video" iteration="i">
             <f:if condition="{i.isFirst}">


### PR DESCRIPTION
Seems like the "renderMode" has been removed see:https://docs.typo3.org/typo3cms/ExtbaseGuide/latest/Fluid/ViewHelper/FlashMessages.html